### PR TITLE
Verify https://sh.rustup.rs (rust/rustup installer)

### DIFF
--- a/.dynamic/verified-hashes.json
+++ b/.dynamic/verified-hashes.json
@@ -28,5 +28,15 @@
         "url": "https://github.com/small-tech/should-i-pipe-it/pull/3"
       }
     ]
+  },
+  "a7eb95476659f5482345376c09cf7bbcc491490d2aca6751de554dcec229cfe9fc2167ea1ec50021560694360abe3a096340301e28540db09ac3615f61c25157": {
+    "url": "https://sh.rustup.rs",
+    "verifiers": [
+      {
+       	"name": "rugk",
+        "isAuthorOfScript": false,
+        "url": "https://github.com/small-tech/should-i-pipe-it/pull/4"
+      }
+    ]
   }
 }

--- a/.dynamic/verified-hashes.json
+++ b/.dynamic/verified-hashes.json
@@ -33,7 +33,7 @@
     "url": "https://sh.rustup.rs",
     "verifiers": [
       {
-       	"name": "rugk",
+        "name": "rugk",
         "isAuthorOfScript": false,
         "url": "https://github.com/small-tech/should-i-pipe-it/pull/4"
       }


### PR DESCRIPTION
From https://www.rust-lang.org/tools/install
https://should-i-pipe.it/https://sh.rustup.rs

What it does: It downloads the (correct) "rustup-init" binary from https://static.rust-lang.org and executes it to install rustup and rust.

SHA512sum: `39ce80b06b2ba8dd74043e04cc973533356c2135be3ee7dd95b47a6ffd380eec555d9e9103d539b1639b3412fa973617b8af97f647ffb13e1f8c536936aaaab3`
SHA256sum: `79552216b4ccab5f773a981bc156b38b004a4f94ac5d2b83f8e127020a4d0bfe`